### PR TITLE
C sharp tool 2023

### DIFF
--- a/src/CSharp_Tool_BGP/ConsoleApplication1/Program.cs
+++ b/src/CSharp_Tool_BGP/ConsoleApplication1/Program.cs
@@ -17,12 +17,31 @@ namespace ConsoleApplication1
         /// The main function is the starting point for the compiler to start compiling the code
         /// </summary>
         /// <param name="args"> The argument list that the user might provide to the main</param>
-        static void Main(string[] args)
+        static int Main(string[] args)
         {
             
             List<pins> PINS = new List<pins>();
 			String file_name = "DUMP";
             int brojac = 0;
+
+            //Exit code = 0 ==> SUCCESS
+            //Exit code = 1 ==> FAILED
+
+            //Parsing Parameters
+            if (args != null && args.Length > 0)
+            {
+                // Checking if INPUT_FILE_PATH was passed by parameter
+                file_name = args[0];
+                Console.WriteLine("INPUT_FILE_PATH parameter was received: " + file_name);
+                
+            }
+
+            //Checking if INPUT_FILE_PATH exists
+            if (!File.Exists(file_name)) {
+                Console.WriteLine("FATAL ERROR: Specified INPUT_FILE_PATH not exists: " + file_name);
+                return 1;
+            }
+            
 
 
             // varijabla koju cemo koristiti, choose FROM AS
@@ -769,6 +788,7 @@ namespace ConsoleApplication1
             }
             streamwriter1.Close();
             streamwriter2.Close();
+            return 0;
         }//end of main
 
 

--- a/src/CSharp_Tool_BGP/Readme.md
+++ b/src/CSharp_Tool_BGP/Readme.md
@@ -1,0 +1,41 @@
+# CSharp Tool BGP
+
+## Description
+
+C Sharp Tool is a tool for extracting features from BGP update files.
+
+These files can be obtained from site collections such as RIPE and Routeviews. After downloading in MRT format, these files need to be converted to ASCII.
+
+## Usage
+
+For execution in Windows environments, the ConsoleApplication1.exe file can be executed directly.
+
+In Linux and MacOS environments, Mono must be used to run the C Sharp Tool
+
+### Case 1: No arguments passed on the command line
+
+```bash
+mono ConsoleApplication1.exe
+```
+
+* INPUT: The program will assume the existence of a DUMP file in the same directory where the .exe file is being executed. If the file does not exist, the program will abort with an error message.
+
+* OUTPUT: The program will create two files in the same directory where the .exe file is being executed. The file names will be: DUMP_featureselection.txt and DUMP_out.txt.
+
+### Case 2: With 1 argument passed on the command line
+```bash
+mono ConsoleApplication1.exe ./dump_examples/DUMP
+```
+
+* INPUT: The program will read the file passed by argument. In the case of the example, the file./dump_examples/DUMP. Any absolute or relative location can be passed. If the file does not exist, the program will abort with an error message.
+
+* OUTPUT: The files created will have the same name and location as the input file, but with the suffixes _featureselection.txt and _out.txt.
+
+## Building
+
+```bash
+cd src/CSharp_Tool_BGP/ConsoleApplication1
+xbuild ConsoleApplication1.csproj
+```
+
+xbuild is Mono’s implementation of msbuild and it allows projects that have an msbuild file to be compiled natively on Linux or MacOS.


### PR DESCRIPTION
# CSharp Tool BGP

## Pull Request

This PR mainly adds flexibility to ConsoleApplication, allowing it to be passed as an argument to the location of the INPUT FILE PATH.

The previous version assumes the existence of the input file in the same directory as the executed file, not allowing the user to specify a location for input and output. This limitation can require that files have to be copied unnecessarily. This also can be a problem when trying to run the program in multiple threads simultaneously.

Due to backward compatibility, it is still possible to use the program without passing any argument. Both cases are specified in the Usage section. Other minor improvements were also deployed:

- Check if the file input exists (covering both cases, with or without arguments)
- Printing a message and aborting execution in case of an invalid file
- Readme.md file with instructions to use and to build the C Sharp Tool

## Description

C Sharp Tool is a tool for extracting features from BGP update files.

These files can be obtained from site collections such as RIPE and Routeviews. After downloading in MRT format, these files need to be converted to ASCII.

## Usage

For execution in Windows environments, the ConsoleApplication1.exe file can be executed directly.

In Linux and MacOS environments, Mono must be used to run the C Sharp Tool

### Case 1: No arguments passed on the command line

```bash
mono ConsoleApplication1.exe
```

* INPUT: The program will assume the existence of a DUMP file in the same directory where the .exe file is being executed. If the file does not exist, the program will abort with an error message.

* OUTPUT: The program will create two files in the same directory where the .exe file is being executed. The file names will be: DUMP_featureselection.txt and DUMP_out.txt.

### Case 2: With 1 argument passed on the command line
```bash
mono ConsoleApplication1.exe ./dump_examples/DUMP
```

* INPUT: The program will read the file passed by argument. In the case of the example, the file./dump_examples/DUMP. Any absolute or relative location can be passed. If the file does not exist, the program will abort with an error message.

* OUTPUT: The files created will have the same name and location as the input file, but with the suffixes _featureselection.txt and _out.txt.

## Building

```bash
cd src/CSharp_Tool_BGP/ConsoleApplication1
xbuild ConsoleApplication1.csproj
```

xbuild is Mono’s implementation of msbuild and it allows projects that have an msbuild file to be compiled natively on Linux or MacOS.